### PR TITLE
moved permissions to dan-deploy-flow

### DIFF
--- a/.github/workflows/dan-deploy-flow.yml
+++ b/.github/workflows/dan-deploy-flow.yml
@@ -3,6 +3,8 @@ name: Reusable dan deploy workflow
 permissions:
   actions: read
   contents: read
+  checks: write
+  pull-requests: write
 
 on:
   workflow_call:

--- a/.github/workflows/post-deploy-test.yml
+++ b/.github/workflows/post-deploy-test.yml
@@ -16,9 +16,6 @@ on:
 jobs:
   post-deploy-tests:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      pull-requests: write
     environment: ${{ inputs.environment }}
     steps:
       - name: 'Checkout'


### PR DESCRIPTION
### Description
<!--- What and why -->
moved permissions so the whole workflow can inherit the permissions
### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to adjust authorization levels for CI/CD pipeline operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->