### PR TITLE
ci: pin github action versions

### DIFF
--- a/.github/workflows/dan-deploy-flow.yml
+++ b/.github/workflows/dan-deploy-flow.yml
@@ -59,8 +59,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # 5.2.0
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
       - name: 'Dotnet restore, build & test'
@@ -87,12 +87,12 @@ jobs:
     needs: [build]
     steps:
       - name: 'Download artifact for dev'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact_name }}
           path: './downloaded-app'
       - name: 'Deploy artifact to dev'
-        uses: azure/functions-action@v1
+        uses: azure/functions-action@02a16c5f3a5707fa97fca56c202cc2ef6cc7dccb # v1.5.4
         with:
           app-name: ${{secrets.function_app_name}}
           package: './downloaded-app'
@@ -115,12 +115,12 @@ jobs:
     needs: [deploy-dev]
     steps:
       - name: 'Download artifact for staging'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact_name }}
           path: './downloaded-app'
       - name: 'Deploy artifact to staging'
-        uses: azure/functions-action@v1
+        uses: azure/functions-action@02a16c5f3a5707fa97fca56c202cc2ef6cc7dccb # v1.5.4
         with:
           app-name: ${{secrets.function_app_name}}
           package: './downloaded-app'
@@ -143,7 +143,7 @@ jobs:
     needs: [deploy-staging]
     steps:
       - name: 'Login via Azure CLI'
-        uses: azure/login@v1
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           creds: ${{ secrets.azure_credentials }}
       - name: 'Swap staging and production'
@@ -159,12 +159,12 @@ jobs:
     needs: [swap-staging-prod]
     steps:
       - name: 'Download artifact for redeploy to staging'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact_name }}
           path: './downloaded-app'
       - name: 'Redeploy artifact to staging'
-        uses: azure/functions-action@v1
+        uses: azure/functions-action@02a16c5f3a5707fa97fca56c202cc2ef6cc7dccb # v1.5.4
         with:
           app-name: ${{secrets.function_app_name}}
           package: './downloaded-app'

--- a/.github/workflows/dan-deploy-flow.yml
+++ b/.github/workflows/dan-deploy-flow.yml
@@ -75,7 +75,7 @@ jobs:
           dotnet publish -c '${{ inputs.build_configuration }}' --no-restore -o './published-app'
         working-directory: ${{ inputs.function_project_path }}
       - name: Upload artifact '${{ inputs.artifact_name }}'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.function_project_path }}/published-app

--- a/.github/workflows/dan-noslots-deploy-flow.yml
+++ b/.github/workflows/dan-noslots-deploy-flow.yml
@@ -33,8 +33,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # 5.2.0
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
       - name: 'Dotnet restore, build & test'
@@ -49,7 +49,7 @@ jobs:
           dotnet publish -c '${{ inputs.build_configuration }}' --no-restore -o './published-app'
         working-directory: ${{ inputs.function_project_path }}
       - name: Upload artifact '${{ inputs.artifact_name }}'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.function_project_path }}/published-app
@@ -61,12 +61,12 @@ jobs:
     needs: [build]
     steps:
       - name: 'Download artifact for dev'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact_name }}
           path: './downloaded-app'
       - name: 'Deploy artifact to dev'
-        uses: azure/functions-action@v1
+        uses: azure/functions-action@02a16c5f3a5707fa97fca56c202cc2ef6cc7dccb # v1.5.4
         with:
           app-name: ${{secrets.function_app_name}}
           package: './downloaded-app'
@@ -79,12 +79,12 @@ jobs:
     needs: [deploy-dev]
     steps:
       - name: 'Download artifact for staging'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact_name }}
           path: './downloaded-app'
       - name: 'Deploy artifact to staging'
-        uses: azure/functions-action@v1
+        uses: azure/functions-action@02a16c5f3a5707fa97fca56c202cc2ef6cc7dccb # v1.5.4
         with:
           app-name: ${{secrets.function_app_name}}
           package: './downloaded-app'
@@ -97,12 +97,12 @@ jobs:
     needs: [deploy-staging]
     steps:
       - name: 'Download artifact for deploy to production'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact_name }}
           path: './downloaded-app'
       - name: 'Deploy artifact to prod'
-        uses: azure/functions-action@v1
+        uses: azure/functions-action@02a16c5f3a5707fa97fca56c202cc2ef6cc7dccb # v1.5.4
         with:
           app-name: ${{secrets.function_app_name}}
           package: './downloaded-app'

--- a/.github/workflows/post-deploy-test.yml
+++ b/.github/workflows/post-deploy-test.yml
@@ -19,7 +19,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: data-altinn-no/k6-tests
       - name: 'Install K6'
@@ -29,11 +29,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install k6
       - name: 'Azure login'
-        uses: azure/login@v1
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: 'Setup environment variables'
-        uses: azure/CLI@v1
+        uses: azure/CLI@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           azcliversion: 2.30.0
           inlineScript: |   
@@ -67,12 +67,12 @@ jobs:
             echo env=${{ inputs.environment }} >> $GITHUB_ENV
             echo GODEBUG=http2client=0 >> $GITHUB_ENV
       - name: "Run K6 tests (${{ inputs.environment }})"
-        uses: grafana/k6-action@v0.2.0
+        uses: grafana/k6-action@55845c6c2e400af4356c84e5b514aeabb1bfdbd4 # v0.2.0
         with:
           filename: postDeployTests.js
           flags: --quiet --log-output=stdout --include-system-env-vars
       - name: 'K6 results'
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           junit_files: 'junit.xml'
       - name: 'Remove Certificate files'


### PR DESCRIPTION
### Description
Pinning external github actions, internal ones (i.e the ones that already point to deploy-actions) will still point to main.

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD security and reliability by pinning workflow action references to specific commits, increasing reproducibility and deployment consistency without changing runtime behavior or job logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->